### PR TITLE
Moved logon banner DSC to SecurityPolicyDsc module

### DIFF
--- a/guest-configuration/WindowsLogonBanner.json
+++ b/guest-configuration/WindowsLogonBanner.json
@@ -14,7 +14,7 @@
             "Description": "Windows logon banner title",
             "ResourceType": "SecurityOption",
             "ResourceId": "Ensure Windows logon banner title is set correctly",
-            "ResourcePropertyName": "Interactive_logon_ Message_title_for_ users_attempting_ to_log_on",
+            "ResourcePropertyName": "Interactive_logon_Message_title_for_users_attempting_to_log_on",
             "DefaultValue": "YOUR LOGON BANNER TITLE HERE"
         },
         {

--- a/guest-configuration/WindowsLogonBanner.json
+++ b/guest-configuration/WindowsLogonBanner.json
@@ -4,7 +4,7 @@
     "Platform": "Windows",
     "Version": "1.0.0",
     "DscModules": [
-        "PSDscResources"
+        "SecurityPolicyDsc"
     ], 
     "PolicyPath": "gc-windows-logon-banner",
     "PolicyParameters": [
@@ -12,18 +12,18 @@
             "Name": "BannerTitle",
             "DisplayName": "Windows logon banner title",
             "Description": "Windows logon banner title",
-            "ResourceType": "Registry",
+            "ResourceType": "SecurityOption",
             "ResourceId": "Ensure Windows logon banner title is set correctly",
-            "ResourcePropertyName": "ValueData",
+            "ResourcePropertyName": "Interactive_logon_ Message_title_for_ users_attempting_ to_log_on",
             "DefaultValue": "YOUR LOGON BANNER TITLE HERE"
         },
         {
             "Name": "BannerText",
             "DisplayName": "Windows logon banner text",
             "Description": "Windows logon banner text",
-            "ResourceType": "Registry",
+            "ResourceType": "SecurityOption",
             "ResourceId": "Ensure Windows logon banner text is set correctly",
-            "ResourcePropertyName": "ValueData",
+            "ResourcePropertyName": "Interactive_logon_Message_text_for_users_attempting_to_log_on",
             "DefaultValue": "YOUR LOGON BANNER TEXT HERE"
         }
     ]

--- a/guest-configuration/WindowsLogonBanner.ps1
+++ b/guest-configuration/WindowsLogonBanner.ps1
@@ -1,8 +1,6 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Install-Module 'PSDscResources'
-
 Configuration WindowsLogonBanner
 {
     param
@@ -14,25 +12,19 @@ Configuration WindowsLogonBanner
         $BannerText
     )
 
-    Import-DscResource -ModuleName 'PSDscResources'
+    Import-DscResource -ModuleName 'SecurityPolicyDsc'
 
     Node localhost {
-        Registry 'Ensure Windows logon banner title is set correctly'
+        SecurityOption 'Ensure Windows logon banner title is set correctly'
         {
-            Ensure = 'Present'
-            Key = "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System"
-            ValueName = "legalnoticecaption"
-            ValueData = $BannerTitle
-            ValueType = "String"
+            Name = "Banner Title"
+            Interactive_logon_Message_title_for_users_attempting_to_log_on = $BannerTitle
         }
 
-        Registry 'Ensure Windows logon banner text is set correctly'
+        SecurityOption 'Ensure Windows logon banner text is set correctly'
         {
-            Ensure = 'Present'
-            Key = "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System"
-            ValueName = "legalnoticetext"
-            ValueData = $BannerText
-            ValueType = "String"
+            Name = "Banner Text"
+            Interactive_logon_Message_text_for_users_attempting_to_log_on = $BannerText
         }
     }
 }


### PR DESCRIPTION
Resolves an issue in the Windows logon banner guest configuration which prevented it from working. Users of the policy can now provide banner title and text strings as parameters. Fixes #12 