### PR TITLE
Fix #24

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "markdownlint.config": {
+        "MD028": false,
+        "MD025": {
+            "front_matter_title": ""
+        }
+    }
+}


### PR DESCRIPTION
this fixes the errors in #24 
- fixed MOF build order to be correct, after loading modules
- fixed module loading logic
- added the required -policyID parameter with New-Guid for policy definitions for GuestConfiguration module versions after 3.1.3