### PR TITLE
Fix DCR targeting

### DIFF
--- a/arm-cloudsoe-image.json
+++ b/arm-cloudsoe-image.json
@@ -3012,7 +3012,7 @@
                 "arguments": "[concat(resourceGroup().name, ' ', variables('imagePropertiesSet')[parameters('buildImages')[copyIndex()]].soeSku, ' ', concat('BuildOutput-',copyIndex()))]",
                 "scriptContent": "
                     az login --identity
-                    az image builder run -g $1 -n $2
+                    az image builder run -g $1 -n $2 --no-wait
                     az image builder show-runs -g $1 -n $2 --output-name $3 > $AZ_SCRIPTS_OUTPUT_PATH
                 ",
                 "cleanupPreference": "OnSuccess",

--- a/arm-cloudsoe-image.json
+++ b/arm-cloudsoe-image.json
@@ -3025,14 +3025,14 @@
             "type": "array",
             "copy": {
                 "count": "[length(parameters('buildImages'))]",
-                "input": "[if(equals(variables('imagePropertiesSet')[parameters('buildImages')[copyIndex()]].osType,'Windows'),reference(concat('AIBImageBuild-',copyIndex())).outputs.artifactId,null())]"
+                "input": "[if(equals(variables('imagePropertiesSet')[parameters('buildImages')[copyIndex()]].osType,'Windows'),resourceId('Microsoft.Compute/galleries/images','CloudSOESIG',variables('imagePropertiesSet')[parameters('buildImages')[copyIndex()]].soeSku),null())]"
             }
         },
         "linuxImageIds": {
             "type": "array",
             "copy": {
                 "count": "[length(parameters('buildImages'))]",
-                "input": "[if(equals(variables('imagePropertiesSet')[parameters('buildImages')[copyIndex()]].osType,'Linux'),reference(concat('AIBImageBuild-',copyIndex())).outputs.artifactId,null())]"
+                "input": "[if(equals(variables('imagePropertiesSet')[parameters('buildImages')[copyIndex()]].osType,'Linux'),resourceId('Microsoft.Compute/galleries/images','CloudSOESIG',variables('imagePropertiesSet')[parameters('buildImages')[copyIndex()]].soeSku),null())]"
             }
         }
     }

--- a/arm-cloudsoe-image.json
+++ b/arm-cloudsoe-image.json
@@ -3013,7 +3013,6 @@
                 "scriptContent": "
                     az login --identity
                     az image builder run -g $1 -n $2 --no-wait
-                    az image builder show-runs -g $1 -n $2 --output-name $3 > $AZ_SCRIPTS_OUTPUT_PATH
                 ",
                 "cleanupPreference": "OnSuccess",
                 "retentionInterval": "P1D"


### PR DESCRIPTION
Data Collection Rule policies were not applying to VMs built from the SOE images, as the image reference was incorrect. This PR also removes a dependency which allows async image images with --no-wait.