### PR TITLE
Fix multiple instances of xpath non-compliance

### DIFF
--- a/arm-cloudsoe-la-solutions.json
+++ b/arm-cloudsoe-la-solutions.json
@@ -218,8 +218,8 @@
                                 "Microsoft-Event"
                             ],
                             "xPathQueries": [
-                                "Microsoft-Windows-Windows Defender/Operational!*[System[((EventID &gt;= 1121 and EventID &lt;= 1122))]]",
-                                "Microsoft-Windows-Windows Defender/WHC!*[System[((EventID &gt;= 1121 and EventID &lt;= 1122))]]"
+                                "Microsoft-Windows-Windows Defender/Operational!*[System[((EventID >= 1121 and EventID <= 1122))]]",
+                                "Microsoft-Windows-Windows Defender/WHC!*[System[((EventID >= 1121 and EventID <= 1122))]]"
                             ],
                             "name": "ASREvents"
                         }
@@ -259,7 +259,7 @@
                                 "Microsoft-Event"
                             ],
                             "xPathQueries": [
-                                "Microsoft-Windows-NTLM/Operational!*[System[((EventID &gt;= 8001 and EventID &lt;= 8004))]]"
+                                "Microsoft-Windows-NTLM/Operational!*[System[((EventID >= 8001 and EventID <= 8004))]]"
                             ],
                             "name": "NTLMEvents"
                         }
@@ -299,8 +299,8 @@
                                 "Microsoft-Event"
                             ],
                             "xPathQueries": [
-                                "Microsoft-Windows-Security-Mitigations/KernelMode!*[System[((EventID &gt;= 1 and EventID &lt;= 24))]]",
-                                "Microsoft-Windows-Security-Mitigations/UserMode!*[System[((EventID &gt;= 1 and EventID &lt;= 24))]]",
+                                "Microsoft-Windows-Security-Mitigations/KernelMode!*[System[((EventID >= 1 and EventID <= 24))]]",
+                                "Microsoft-Windows-Security-Mitigations/UserMode!*[System[((EventID >= 1 and EventID <= 24))]]",
                                 "Microsoft-Windows-Win32k/Operational!*[System[((EventID=260))]]",
                                 "System!*[System[Provider[@Name='Microsoft-Windows-WER-Diag'] and (EventID=5)]]"    
                             ],
@@ -342,7 +342,7 @@
                                 "Microsoft-Event"
                             ],
                             "xPathQueries": [
-                                "Security!*[System[((EventID &gt;= 4650 and EventID &lt;= 4651))]]", //Main mode security associations
+                                "Security!*[System[((EventID >= 4650 and EventID <= 4651))]]", //Main mode security associations
                                 "Security!*[System[((EventID=5451))]]"                               //Quick mode security associations
                             ],
                             "name": "IPsecEvents"
@@ -383,8 +383,8 @@
                                 "Microsoft-Event"
                             ],
                             "xPathQueries": [
-                                "Microsoft-Windows-Windows Defender/Operational!*[System[((EventID &gt;= 1125 and EventID &lt;= 1126))]]",
-                                "Microsoft-Windows-Windows Defender/WHC!*[System[((EventID &gt;= 1125 and EventID &lt;= 1126))]]"  
+                                "Microsoft-Windows-Windows Defender/Operational!*[System[((EventID >= 1125 and EventID <= 1126))]]",
+                                "Microsoft-Windows-Windows Defender/WHC!*[System[((EventID >= 1125 and EventID <= 1126))]]"  
                             ],
                             "name": "NetworkProtectionEvents"
                         }


### PR DESCRIPTION
Data Collection Rules were created with incorrect xpath syntax. I.e. using &gt; and &lt; instead of > <.